### PR TITLE
Wrap field.error in Messages

### DIFF
--- a/app/views/bootstrap3/checkboxes.scala.html
+++ b/app/views/bootstrap3/checkboxes.scala.html
@@ -15,6 +15,6 @@
         </label>
       }
       <span class="help-block">@help</span>
-      <span class="help-block">@{field.error.map { error => error.message }}</span>
+      <span class="help-block">@{field.error.map { error => Messages(error.message) }}</span>
     </div>
   </div>

--- a/app/views/bootstrap3/password.scala.html
+++ b/app/views/bootstrap3/password.scala.html
@@ -11,6 +11,6 @@
         value="@field.value.getOrElse("")"
         placeholder="@placeholder" />
       <span class="help-block">@help</span>
-      <span class="help-block">@{field.error.map { error => error.message }}</span>
+      <span class="help-block">@{field.error.map { error => Messages(error.message) }}</span>
     </div>
   </div>

--- a/app/views/bootstrap3/radiobuttons.scala.html
+++ b/app/views/bootstrap3/radiobuttons.scala.html
@@ -15,6 +15,6 @@
       </label>
       }
       <span class="help-block">@help</span>
-      <span class="help-block">@{field.error.map { error => error.message }}</span>
+      <span class="help-block">@{field.error.map { error => Messages(error.message) }}</span>
     </div>
   </div>

--- a/app/views/bootstrap3/select.scala.html
+++ b/app/views/bootstrap3/select.scala.html
@@ -14,6 +14,6 @@
         }
       </select>
       <span class="help-block">@help</span>
-      <span class="help-block">@{field.error.map { error => error.message }}</span>
+      <span class="help-block">@{field.error.map { error => Messages(error.message) }}</span>
     </div>
   </div>

--- a/app/views/bootstrap3/text.scala.html
+++ b/app/views/bootstrap3/text.scala.html
@@ -10,6 +10,6 @@
              value="@field.value.getOrElse("")"
              placeholder="@placeholder" />
       <span class="help-block">@help</span>
-      <span class="help-block">@{field.error.map { error => error.message }}</span>
+      <span class="help-block">@{field.error.map { error => Messages(error.message) }}</span>
     </div>
   </div>

--- a/app/views/bootstrap3/textarea.scala.html
+++ b/app/views/bootstrap3/textarea.scala.html
@@ -10,6 +10,6 @@
                 placeholder="@placeholder" 
                 >@field.value.getOrElse("")</textarea>
       <span class="help-block">@help</span>
-      <span class="help-block">@{field.error.map { error => error.message }}</span>
+      <span class="help-block">@{field.error.map { error => Messages(error.message) }}</span>
     </div>
   </div>


### PR DESCRIPTION
FieldElements has some special logic to wrap a field with a FormError that has a value with a message key through Messages:

https://github.com/playframework/playframework/blob/2.2.x/framework/src/play/src/main/scala/views/helper/Helpers.scala#L34

Because the fragments here are using raw Field, that functionality is not there, so it must be added to the fragements.
